### PR TITLE
chore(cd): add continuous delivery and auto merge dependabot PRs

### DIFF
--- a/.github/workflows/auto_merge_prs.yml
+++ b/.github/workflows/auto_merge_prs.yml
@@ -1,0 +1,37 @@
+# auto merge workflow.
+#
+# Auto merge PR if commit msg begins with `chore(release):`,
+# or if it has been raised by Dependabot.
+# Uses https://github.com/ridedott/merge-me-action.
+
+name: Merge Version Change and Dependabot PRs automatically
+
+on: pull_request
+
+jobs:
+  merge:
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      with:
+        fetch-depth: '0'
+
+    - name: get commit message
+      run: |
+           echo ::set-env name=commitmsg::$(git log --format=%B -n 1 ${{ github.event.pull_request.head.sha }})
+    - name: show commit message
+      run : echo $commitmsg
+
+    - name: Merge Version change PR
+      if: startsWith( env.commitmsg, 'chore(release):')
+      uses: ridedott/merge-me-action@81667e6ae186ddbe6d3c3186d27d91afa7475e2c
+      with:
+        GITHUB_LOGIN: dirvine
+        GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        MERGE_METHOD: REBASE
+
+    - name: Dependabot Merge
+      uses: ridedott/merge-me-action@master
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        MERGE_METHOD: REBASE

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -1,0 +1,24 @@
+name: Version bump and create PR for changes
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+
+jobs:
+  update_changelog:
+    runs-on: ubuntu-20.04
+    # Dont run if we're on a release commit
+    if: "!startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+      - name: Bump Version
+        uses: maidsafe/rust-version-bump-branch-creator@v2
+        with:
+          token: ${{ secrets.BRANCH_CREATOR_TOKEN }}

--- a/.github/workflows/commitlint.yml
+++ b/.github/workflows/commitlint.yml
@@ -1,0 +1,13 @@
+name: Commitlint
+on: [pull_request]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: wagoid/commitlint-github-action@f114310111fdbd07e99f47f9ca13d62b3ec98372

--- a/.github/workflows/github_release.yml
+++ b/.github/workflows/github_release.yml
@@ -1,0 +1,37 @@
+name: Create GitHub Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    # only if we have a tag
+    name: Release
+    runs-on: ubuntu-20.04
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: '0'
+
+      - name: Set tag as env
+        shell: bash
+        run: echo ::set-env name=RELEASE_VERSION::$(echo ${GITHUB_REF:10})
+
+      - name: lets check tag
+        shell: bash
+        run: echo ${{ env.RELEASE_VERSION }}
+
+      - name: Generate Changelog
+        shell: bash
+        run: awk '/# \[/{c++;p=1}{if(c==2){exit}}p;' CHANGELOG.md > RELEASE-CHANGELOG.txt
+      - run: cat RELEASE-CHANGELOG.txt
+      - name: Release generation
+        uses: softprops/action-gh-release@91409e712cf565ce9eff10c87a8d1b11b81757ae
+        env:
+          GITHUB_TOKEN: ${{ secrets.MERGE_BUMP_BRANCH_TOKEN }}
+        with:
+          body_path: RELEASE-CHANGELOG.txt

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -1,0 +1,78 @@
+# Push to master workflow.
+#
+# Runs when a PR has been merged to the master branch.
+#
+# 1. Generates a release build.
+# 2. If the last commit is a version change, publish.
+
+name: Master
+
+on:
+  push:
+    branches:
+      - master
+
+env:
+  # Run all cargo commands with --verbose.
+  CARGO_TERM_VERBOSE: true
+  RUST_BACKTRACE: 1
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Generate Cargo.lock, needed for the cache.
+      - name: Generate Cargo.lock
+        run: cargo generate-lockfile
+
+      # Cache.
+      - name: Cargo cache registry, index and build
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-cache-${{ hashFiles('**/Cargo.lock') }}
+
+      # Make sure the code builds.
+      - name: Cargo Build
+        run: cargo build --release
+
+  # Publish if we're on a release commit
+  publish:
+    name: Publish
+    runs-on: ubuntu-latest
+    needs: build
+    if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+    steps:
+      - uses: actions/checkout@v2
+      # checkout with fetch-depth: '0' to be sure to retrieve all commits to look for the semver commit message
+        with:
+          fetch-depth: '0'
+     
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Publish to crates.io.
+      - name: Cargo Login
+        run: cargo login ${{ secrets.CRATES_IO_TOKEN }}
+
+      - name: Cargo Publish
+        run: cargo publish

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -126,3 +126,20 @@ jobs:
       # Run tests.
       - shell: bash
         run: ./scripts/tests
+
+  # Test publish using --dry-run.
+  test-publish:
+    name: Test Publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      # Install Rust
+      - uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+
+      # Cargo publish dry run
+      - name: Cargo Publish Dry Run
+        run: cargo publish --dry-run

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,37 @@
+name: Tag release commit
+
+on:
+  # Trigger the workflow on push only for the master branch
+  push:
+    branches:
+      - master
+
+env:
+  NODE_ENV: 'development'
+  GITHUB_TOKEN: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+
+jobs:
+  tag:
+      runs-on: ubuntu-latest
+      # Only run on a release commit
+      if: "startsWith(github.event.head_commit.message, 'chore(release):')"
+      steps:
+        - uses: actions/checkout@v2
+          with:
+            fetch-depth: '0'
+            token: ${{ secrets.BRANCH_CREATOR_TOKEN }}
+        - run: echo ::set-env name=RELEASE_VERSION::$(git log -1 --pretty=%B)
+        # parse out non-tag text
+        - run: echo ::set-env name=RELEASE_VERSION::$( echo $RELEASE_VERSION | sed 's/chore(release)://' )
+        # remove spaces, but add back in `v` to tag, which is needed for standard-version
+        - run: echo ::set-env name=RELEASE_VERSION::v$(echo $RELEASE_VERSION | tr -d '[:space:]')
+        - run: echo $RELEASE_VERSION
+        - run: git tag $RELEASE_VERSION
+
+        - name: Setup git for push
+          run: |
+            git remote add github "$REPO"
+            git config --local user.email "action@github.com"
+            git config --local user.name "GitHub Action"
+        - name: Push tags to master
+          run: git push "https://$GITHUB_ACTOR:$GITHUB_TOKEN@github.com/$GITHUB_REPOSITORY" HEAD:master --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,159 +1,159 @@
-# [master]
+# Changelog
 
-# [0.13.3] 2020-09-01
+### [0.13.3](https://github.com/maidsafe/sn_bindgen/compare/v0.13.2...v0.13.3) 2020-09-01
 
-- rename crate to sn_bindgen as per new naming convention
-- add option to copy to/from List<string>
+* rename crate to sn_bindgen as per new naming convention
+* add option to copy to/from List<string>
 
-# [0.13.2] 2019-11-03
+### [0.13.2](https://github.com/maidsafe/sn_bindgen/compare/v0.13.1...v0.13.2) 2019-11-03
 
-- Add support for negative constants in C sharp
+* Add support for negative constants in C sharp
 
-# [0.13.1] - 2019-09-02
+### [0.13.1] - 2019-09-02
 
-- Fix C parser erroring on enum variants with values
+* Fix C parser erroring on enum variants with values
 
-# [0.13.0] - 2019-05-29
+### [0.13.0] - 2019-05-29
 
-- Update clap dependency to the latest version
+* Update clap dependency to the latest version
 
-# [0.12.0] - 2019-04-12
+### [0.12.0] - 2019-04-12
 
-- Switch from a deprecated parsing library `syntex` to `syn`.
-- Fix inconsitencies and bugs in the C# module.
-- Add more tests for Java & JNI modules.
-- Use stable Rust (edition 2018).
+* Switch from a deprecated parsing library `syntex` to `syn`.
+* Fix inconsitencies and bugs in the C# module.
+* Add more tests for Java & JNI modules.
+* Use stable Rust (edition 2018).
 
-# [0.11.0] - 2018-11-15
+### [0.11.0] - 2018-11-15
 
-- Allow to filter symbols in Java bindgen. This can be used for manual reimplementation of
+* Allow to filter symbols in Java bindgen. This can be used for manual reimplementation of
   certain JNI functions in special cases.
-- Pass through the compiler feature flags for generated JNI functions (as some functions
+* Pass through the compiler feature flags for generated JNI functions (as some functions
   can be feature-gated).
-- Fix leaking local references. Because the Android local reference table is limited to 512
+* Fix leaking local references. Because the Android local reference table is limited to 512
   entries it is important to deallocate the local references as soon as possible.
 
-# [0.10.0] - 2018-09-18
+### [0.10.0] - 2018-09-18
 
-- Use `EnvGuard` from `ffi_utils` to detach JNI threads only when needed (i.e. if we
+* Use `EnvGuard` from `ffi_utils` to detach JNI threads only when needed (i.e. if we
   successfully acquire JNI environment through `GetEnv()`, we do not need to detach the
   native thread)
-- Change the class finder function signature (now it returns result wrapped
+* Change the class finder function signature (now it returns result wrapped
   as `Result<AutoLocal, JniError>`)
 
-# [0.9.0] - 2018-09-13
+### [0.9.0] - 2018-09-13
 
-- Use custom cached class loader for Java/JNI objects instantiation (this fixes the Android
+* Use custom cached class loader for Java/JNI objects instantiation (this fixes the Android
   freezing issue)
 
-# [0.8.0] - 2018-09-04
+### [0.8.0] - 2018-09-04
 
-- Support new API to pass input source code as a string (`Bindgen::source_code`)
+* Support new API to pass input source code as a string (`Bindgen::source_code`)
 
-# [0.7.0] - 2018-08-28
+### [0.7.0] - 2018-08-28
 
-- Upgrade unwrap version to 1.2.0
-- Use rust 1.28.0 stable / 2018-07-07 nightly
-- rustfmt 0.99.2 and clippy-0.0.212
+* Upgrade unwrap version to 1.2.0
+* Use rust 1.28.0 stable / 2018-07-07 nightly
+* rustfmt 0.99.2 and clippy-0.0.212
 
-# [0.6.0] - 2018-08-10
+### [0.6.0] - 2018-08-10
 
-- Fix `illegal class name` error in Java/JNI
-- Fix `pub(crate)` items being parsed as a part of public API
-- Update `syntex_syntax` dependency to 0.59.0
-- Add more tests for the C language
+* Fix `illegal class name` error in Java/JNI
+* Fix `pub(crate)` items being parsed as a part of public API
+* Update `syntex_syntax` dependency to 0.59.0
+* Add more tests for the C language
 
-# [0.5.2] - 2018-07-03
+### [0.5.2] - 2018-07-03
 
-- Make generated C# delegates readonly
+* Make generated C# delegates readonly
 
-# [0.5.1] - 2018-06-26
+### [0.5.1] - 2018-06-26
 
-- Fix incorrectly generated C# delegates: they were garbage collected because of automatically
+* Fix incorrectly generated C# delegates: they were garbage collected because of automatically
   created and recycled references. Instead, we use static references now.
-- Change license to dual MIT/BSD.
+* Change license to dual MIT/BSD.
 
-# [0.5.0] - 2018-06-14
+### [0.5.0] - 2018-06-14
 
-- Support multiple output languages.
-- Add Java/JNI generators.
-- Add C# generator.
-- Fix C headers dependencies resolving (i.e. output header includes in the correct order).
+* Support multiple output languages.
+* Add Java/JNI generators.
+* Add C# generator.
+* Fix C headers dependencies resolving (i.e. output header includes in the correct order).
 
-# [0.4.1] - 2017-04-11
+### [0.4.1] - 2017-04-11
 
-## Fixed
+### Fixed
 
-- Bump syntex dependency version.
+* Bump syntex dependency version.
 
-# [0.4.0] - 2017-04-05
+### [0.4.0] - 2017-04-05
 
-## Changed
+### Changed
 
-- Rename to moz-cheddar.
-- `enum` values are prefixed with the type name on the C side.
-- nullable `Option<fn(..)>` types convert to function pointers.
+* Rename to moz-cheddar.
+* `enum` values are prefixed with the type name on the C side.
+* nullable `Option<fn(..)>` types convert to function pointers.
 
-## Fixed
+### Fixed
 
-- Bump dependency versions.
-- Make `syntex` an optional feature.
-- Documentation cleanup.
+* Bump dependency versions.
+* Make `syntex` an optional feature.
+* Documentation cleanup.
 
-# [0.3.3] - 2016-05-03
+### [0.3.3] - 2016-05-03
 
-## Fixed
+### Fixed
 
-- arbitrarily nested `const` pointers are handled correctly
-- function declarations can now contain patterns
+* arbitrarily nested `const` pointers are handled correctly
+* function declarations can now contain patterns
     - such as `fn foo(mut a: ...`
-- zero argument functions are now written out as `func(void)`
+* zero argument functions are now written out as `func(void)`
 
-# [0.3.2] - 2016-03-02
+### [0.3.2] - 2016-03-02
 
-## Changed
+### Changed
 
-- rusty-cheddar now correctly converts types in `std::os::raw`
+* rusty-cheddar now correctly converts types in `std::os::raw`
 
-# [0.3.1] - 2016-01-20
+### [0.3.1] - 2016-01-20
 
-## Changed
+### Changed
 
-- the api can now be placed in any arbitrary module
+* the api can now be placed in any arbitrary module
 
-## Fixed
+### Fixed
 
-- the include guard is sanitised to avoid illegal characters in a macro definition
+* the include guard is sanitised to avoid illegal characters in a macro definition
 
 
-# [0.3.0] - 2016-01-10
+### [0.3.0] - 2016-01-10
 
-## Changed
+### Changed
 
-- the whole fucking thing!
+* the whole fucking thing!
     - no longer requires nightly
     - works as a library which leverages syntex
     - see the README for the new interface
 
-## Added
+### Added
 
-- the `cheddar` executable which acts as a thin wrapper around the library functionality
+* the `cheddar` executable which acts as a thin wrapper around the library functionality
 
 
-# [0.2.0] - 2015-12-28
+### [0.2.0] - 2015-12-28
 
-## Added
+### Added
 
-- support for function pointers
-- support for opaque structs
+* support for function pointers
+* support for opaque structs
     - `#[repr(C)] pub struct Foo(Vec<T>);`
     - `typedef struct Foo Foo;`
-- the ability to hide your C API behind a module
+* the ability to hide your C API behind a module
     - can only be one module deep at this point in time
 
-## Changed
+### Changed
 
-- plugin arguments
+* plugin arguments
     - you must now use key value pairs to specify `file` and `dir`
     - old: `#![plugin(cheddar(path,to,file))]`
     - new: `#![plugin(cheddar(dir = "path/to", file = "file.h"))]`


### PR DESCRIPTION
Implement a CD process where any PR merged to master will
automatically trigger a crate publish, a tag, a 'chore(release):'
PR which is auto merged, and a GitHub release.
This PR also adds auto merging for dependabot PRs which pass CI.
This PR also reformats the changelog to match the newly auto-
generated format.